### PR TITLE
remove tracking code from yekpay

### DIFF
--- a/src/Yekpay/Yekpay.php
+++ b/src/Yekpay/Yekpay.php
@@ -287,7 +287,6 @@ class Yekpay extends PortAbstract implements PortInterface
         curl_close($ch);
 
         if ($response['Code'] == 100) {
-            $this->trackingCode = $response['Tracking'];
             $this->transactionSucceed();
             $this->newLog(1, Enum::TRANSACTION_SUCCEED_TEXT);
             return true;


### PR DESCRIPTION
I removed a code from the yekpay.php file that appears during payment verification and checks the tracking_code parameter. According to the documents, there was no need for this.